### PR TITLE
Add selectingParentSelectsChildren argument

### DIFF
--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -70,12 +70,13 @@ export const TableRowMeta = EmberObject.extend({
   ),
 
   isGroupSelected: computed(
-    '_tree.{selection.[],selectionMatchFunction}',
+    '_tree.{selection.[],selectionMatchFunction,selectingParentSelectsChildren}',
     '_parentMeta.isSelected',
     function() {
       let rowValue = get(this, '_rowValue');
       let selection = get(this, '_tree.selection');
       let selectionMatchFunction = get(this, '_tree.selectionMatchFunction');
+      let selectingParentSelectsChildren = get(this, '_tree.selectingParentSelectsChildren');
 
       if (!selection || !isArray(selection)) {
         return false;
@@ -84,7 +85,12 @@ export const TableRowMeta = EmberObject.extend({
       let isSelectionMatch = selectionMatchFunction
         ? selection.filter(item => selectionMatchFunction(item, rowValue)).length > 0
         : selection.includes(rowValue);
-      return isSelectionMatch || get(this, '_parentMeta.isGroupSelected');
+
+      // Only consider parent selection if selectingParentSelectsChildren is true
+      let parentIsSelected =
+        selectingParentSelectsChildren && get(this, '_parentMeta.isGroupSelected');
+
+      return isSelectionMatch || parentIsSelected;
     }
   ),
 

--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -330,17 +330,19 @@ export const TableRowMeta = EmberObject.extend({
       reduceSelectedRows(selection, groupingCounts, rowMetaCache);
     }
 
-    for (let rowMeta of rowMetas) {
-      let rowValue = get(rowMeta, '_rowValue');
-      let parentMeta = get(rowMeta, '_parentMeta');
+    if (selectingParentSelectsChildren) {
+      for (let rowMeta of rowMetas) {
+        let rowValue = get(rowMeta, '_rowValue');
+        let parentMeta = get(rowMeta, '_parentMeta');
 
-      while (parentMeta) {
-        if (selection.has(get(parentMeta, '_rowValue'))) {
-          selection.delete(rowValue);
-          break;
+        while (parentMeta) {
+          if (selection.has(get(parentMeta, '_rowValue'))) {
+            selection.delete(rowValue);
+            break;
+          }
+
+          parentMeta = get(parentMeta, '_parentMeta');
         }
-
-        parentMeta = get(parentMeta, '_parentMeta');
       }
     }
 

--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -46,12 +46,13 @@ export const TableRowMeta = EmberObject.extend({
 
   // eslint-disable-next-line ember/use-brace-expansion
   isSelected: computed(
-    '_tree.{selection.[],selectionMatchFunction}',
+    '_tree.{selection.[],selectionMatchFunction,selectingParentSelectsChildren}',
     '_parentMeta.isSelected',
     function() {
       let rowValue = get(this, '_rowValue');
       let selection = get(this, '_tree.selection');
       let selectionMatchFunction = get(this, '_tree.selectionMatchFunction');
+      let selectingParentSelectsChildren = get(this, '_tree.selectingParentSelectsChildren');
 
       if (isArray(selection)) {
         return this.get('isGroupSelected');
@@ -60,7 +61,11 @@ export const TableRowMeta = EmberObject.extend({
       let isRowSelection = selectionMatchFunction
         ? selectionMatchFunction(selection, rowValue)
         : selection === rowValue;
-      return isRowSelection || get(this, '_parentMeta.isSelected');
+
+      // Only consider parent selection if selectingParentSelectsChildren is true
+      let parentIsSelected = selectingParentSelectsChildren && get(this, '_parentMeta.isSelected');
+
+      return isRowSelection || parentIsSelected;
     }
   ),
 

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -97,6 +97,14 @@ export default Component.extend({
   selectingChildrenSelectsParent: defaultTo(true),
 
   /**
+    When true, this option causes selecting a node to also select all of the node's children.
+
+    @argument selectingParentSelectsChildren
+    @type boolean
+  */
+  selectingParentSelectsChildren: defaultTo(true),
+
+  /**
     The currently selected rows. Can either be an array or an individual row.
 
     @argument selection
@@ -311,6 +319,7 @@ export default Component.extend({
     'selection',
     'selectionMatchFunction',
     'selectingChildrenSelectsParent',
+    'selectingParentSelectsChildren',
     'onSelect',
 
     function() {
@@ -326,6 +335,10 @@ export default Component.extend({
       this.collapseTree.set(
         'selectingChildrenSelectsParent',
         this.get('selectingChildrenSelectsParent')
+      );
+      this.collapseTree.set(
+        'selectingParentSelectsChildren',
+        this.get('selectingParentSelectsChildren')
       );
     }
   ),

--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -305,6 +305,14 @@ export default Component.extend({
       'You must create an <EmberThead /> with columns before creating an <EmberTbody />',
       !!this.get('unwrappedApi.columnTree')
     );
+
+    assert(
+      'You cannot set selectingChildrenSelectsParent to true if selectingParentSelectsChildren is false',
+      !(
+        this.get('selectingParentSelectsChildren') === false &&
+        this.get('selectingChildrenSelectsParent') === true
+      )
+    );
   },
 
   _updateDataTestRowCount() {

--- a/tests/dummy/app/components/examples/selection-modes/template.hbs
+++ b/tests/dummy/app/components/examples/selection-modes/template.hbs
@@ -9,6 +9,7 @@
       @rowSelectionMode={{this.rowSelectionMode}}
       @checkboxSelectionMode={{this.checkboxSelectionMode}}
       @selectingChildrenSelectsParent={{this.selectingChildrenSelectsParent}}
+      @selectingParentSelectsChildren={{this.selectingParentSelectsChildren}}
 
       @onSelect={{action (mut demoSelection)}}
       @selection={{this.demoSelection}}
@@ -34,6 +35,10 @@
 <div class="demo-options-group">
   <h4>selectingChildrenSelectsParent</h4>
   <label> <Input @type="checkbox" @checked={{selectingChildrenSelectsParent}} /> </label>
+</div>
+<div class="demo-options-group">
+  <h4>selectingParentSelectsChildren</h4>
+  <label> <Input @type="checkbox" @checked={{selectingParentSelectsChildren}} /> </label>
 </div>
 
 {{! END-SNIPPET }}

--- a/tests/dummy/app/controllers/docs/guides/body/row-selection.js
+++ b/tests/dummy/app/controllers/docs/guides/body/row-selection.js
@@ -69,6 +69,7 @@ export default Controller.extend({
   rowSelectionMode: 'multiple',
   checkboxSelectionMode: 'multiple',
   selectingChildrenSelectsParent: true,
+  selectingParentSelectsChildren: true,
 
   rowsWithChildren: computed(function() {
     let makeRow = (id, { children } = { children: [] }) => {

--- a/tests/dummy/app/templates/docs/guides/body/row-selection.md
+++ b/tests/dummy/app/templates/docs/guides/body/row-selection.md
@@ -45,7 +45,7 @@ the table.
 
 ## Selection Modes
 
-There are three different properties you can use to control the behavior of
+There are four different properties you can use to control the behavior of
 row selection:
 
 1. `checkboxSelectionMode`: This controls the behavior of the checkbox that
@@ -66,6 +66,9 @@ checkbox will _not_ be checked.
 whether selecting all of the children of a given row also selects the row
 itself.
 
+4. `selectingParentSelectsChildren`: This is a boolean flag that determines
+whether selecting a given row also selects all of its children.
+
 {{#docs-demo as |demo|}}
   {{#demo.example name='selection-modes'}}
     {{examples/selection-modes
@@ -74,6 +77,7 @@ itself.
       rowSelectionMode=this.rowSelectionMode
       checkboxSelectionMode=this.checkboxSelectionMode
       selectingChildrenSelectsParent=this.selectingChildrenSelectsParent
+      selectingParentSelectsChildren=this.selectingParentSelectsChildren
       demoSelection=this.demoSelection}}
   {{/demo.example}}
 

--- a/tests/helpers/generate-table.js
+++ b/tests/helpers/generate-table.js
@@ -54,6 +54,7 @@ const fullTable = hbs`
         @idForFirstItem={{this.idForFirstItem}}
         @onSelect={{action this.onSelect}}
         @selectingChildrenSelectsParent={{this.selectingChildrenSelectsParent}}
+        @selectingParentSelectsChildren={{this.selectingParentSelectsChildren}}
         @checkboxSelectionMode={{this.checkboxSelectionMode}}
         @rowSelectionMode={{this.rowSelectionMode}}
         @rowToggleMode={{this.rowToggleMode}}

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -840,6 +840,35 @@ module('Integration | selection', () => {
       assert.ok(table.validateSelected(1, 2, 3), 'only children are selected');
     });
 
+    test('selecting the parent selects all children when enabled', async function(assert) {
+      await generateTable(this, {
+        selectingParentSelectsChildren: true,
+        rowCount: 3,
+        rowDepth: 2,
+      });
+
+      assert.ok(table.validateSelected(), 'rows are not selected');
+
+      await table.selectRow(0);
+
+      assert.ok(table.validateSelected(0, 1, 2, 3), 'row and its children are selected');
+    });
+
+    test('selecting the parent does not select all children', async function(assert) {
+      await generateTable(this, {
+        selectingChildrenSelectsParent: false,
+        selectingParentSelectsChildren: false,
+        rowCount: 3,
+        rowDepth: 2,
+      });
+
+      assert.ok(table.validateSelected(), 'rows are not selected');
+
+      await table.selectRow(0);
+
+      assert.ok(table.validateSelected(0), 'only parent is selected');
+    });
+
     test('rows can be selected using selectionMatchFunction', async function(assert) {
       let selection = emberA();
       let rows = [

--- a/types/components/ember-tbody/component.d.ts
+++ b/types/components/ember-tbody/component.d.ts
@@ -107,6 +107,11 @@ export interface EmberTbodyArgs<RowType extends EmberTableRow> {
   selectingChildrenSelectsParent?: boolean;
 
   /**
+   * When `true`, this option causes selecting a node to also select all of its children.
+   */
+  selectingParentSelectsChildren?: boolean;
+
+  /**
    * The currently selected rows.
    * Can either be an array or an individual row.
    */


### PR DESCRIPTION
## Context
We have a use case where we want to be able to select a parent row without its children rows getting selected.

This MR adds a `selectingParentSelectsChildren` argument to the `ember-tbody` component which defaults to `true`. When setting this argument to `false`, selecting a parent node won't select the node's children. 

An assertion has been added to disallow setting `selectingParentSelectsChildren` to `false` while `selectingChildrenSelectsParent` is `true` since this would result in weird edge cases where sometimes the parent row has influence on the children and sometimes not.

Some examples of use cases on the web where this also happens: [MUI tree view](https://stackblitz.com/edit/react-e4ebubvj?file=Demo.tsx), [react-checkbox-tree No Cascade Example](https://jakezatecky.github.io/react-checkbox-tree/).

## How to test?
Take a look at the Prism MR: https://git.otainsight.com/ota-insight-repos/ota-insight-platform/ota-insight-frontend/prism/-/merge_requests/1029